### PR TITLE
Add support for leftovers

### DIFF
--- a/src/Pinch/Internal/Parser.hs
+++ b/src/Pinch/Internal/Parser.hs
@@ -15,6 +15,7 @@
 module Pinch.Internal.Parser
     ( Parser
     , runParser
+    , runParser'
 
     , int8
     , int16
@@ -96,6 +97,13 @@ instance Monad Parser where
 runParser :: Parser a -> ByteString -> Either String a
 runParser (Parser f) b = f b Left (const Right)
 {-# INLINE runParser #-}
+
+
+-- | Run the parser on the given ByteString. Return either the failure message
+-- or the result and any left-over content.
+runParser' :: Parser a -> ByteString -> Either String (ByteString, a)
+runParser' (Parser f) b = f b Left (\b' r -> Right (b', r))
+{-# INLINE runParser' #-}
 
 
 -- | @take n@ gets exactly @n@ bytes or fails the parse.

--- a/src/Pinch/Protocol.hs
+++ b/src/Pinch/Protocol.hs
@@ -13,6 +13,7 @@
 -- 'Pinch.Pinchable.Pinchable'.
 module Pinch.Protocol
     ( Protocol(..)
+    , deserializeValue
     ) where
 
 import Data.ByteString (ByteString)
@@ -33,9 +34,15 @@ data Protocol = Protocol
     --
     -- Returns a @Builder@ and the total length of the serialized content.
 
-    , deserializeValue
-        :: forall a. IsTType a => ByteString -> Either String (Value a)
-    -- ^ Reads a 'Value' from a ByteString.
+    , deserializeValue'
+        :: forall a. IsTType a => ByteString -> Either String (ByteString, Value a)
+    -- ^ Reads a 'Value' from a ByteString and returns leftovers from parse.
     , deserializeMessage :: ByteString -> Either String Message
     -- ^ Reads a 'Message' and its payload from a ByteString.
     }
+
+
+-- | Reads a 'Value' from a ByteString.
+deserializeValue :: forall a. IsTType a
+                 => Protocol -> ByteString -> Either String (Value a)
+deserializeValue proto = fmap snd . deserializeValue' proto

--- a/src/Pinch/Protocol/Binary.hs
+++ b/src/Pinch/Protocol/Binary.hs
@@ -31,7 +31,7 @@ import qualified Data.Text.Encoding  as TE
 
 import Pinch.Internal.Builder (Builder)
 import Pinch.Internal.Message
-import Pinch.Internal.Parser  (Parser, runParser)
+import Pinch.Internal.Parser  (Parser, runParser, runParser')
 import Pinch.Internal.TType
 import Pinch.Internal.Value
 import Pinch.Protocol         (Protocol (..))
@@ -45,7 +45,7 @@ import qualified Pinch.Internal.Parser   as P
 binaryProtocol :: Protocol
 binaryProtocol = Protocol
     { serializeValue     = binarySerialize
-    , deserializeValue   = binaryDeserialize ttype
+    , deserializeValue'  = binaryDeserialize ttype
     , serializeMessage   = binarySerializeMessage
     , deserializeMessage = binaryDeserializeMessage
     }
@@ -102,8 +102,8 @@ parseMessageType = P.int8 >>= \code -> case fromMessageCode code of
 
 ------------------------------------------------------------------------------
 
-binaryDeserialize :: TType a -> ByteString -> Either String (Value a)
-binaryDeserialize t = runParser (binaryParser t)
+binaryDeserialize :: TType a -> ByteString -> Either String (ByteString, Value a)
+binaryDeserialize t = runParser' (binaryParser t)
 
 binaryParser :: TType a -> Parser (Value a)
 binaryParser typ = case typ of

--- a/tests/Pinch/Protocol/BinarySpec.hs
+++ b/tests/Pinch/Protocol/BinarySpec.hs
@@ -17,7 +17,7 @@ import Pinch.Internal.Message
 import Pinch.Internal.TType
 import Pinch.Internal.Util
 import Pinch.Internal.Value   (SomeValue (..), Value (..))
-import Pinch.Protocol         (Protocol (..))
+import Pinch.Protocol
 import Pinch.Protocol.Binary  (binaryProtocol)
 
 


### PR DESCRIPTION
This gives the user access to any input content left-over after the parse. This is necessary for some formats where Thrift objects are packed consecutively in a stream.