### PR TITLE
Fix `ar` permission issue for 7.8 on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
     compiler: ": #stack default osx"
     os: osx
 
-  - env: BUILD=stack ARGS="--resolver lts-2"
+  - env: BUILD=stack ARGS="--resolver lts-2 --stack-yaml stack.osx.7.8.yaml"
     compiler: ": #stack 7.8.4 osx"
     os: osx
 

--- a/stack.osx.7.8.yaml
+++ b/stack.osx.7.8.yaml
@@ -1,0 +1,7 @@
+# Workaround for https://github.com/haskell/cabal/issues/2653
+flags: {}
+packages:
+- '.'
+extra-deps:
+  - unix-2.7.1.0
+resolver: lts-2.22


### PR DESCRIPTION
We can probably just drop support for 7.8 in a future version.

Related: https://github.com/haskell/cabal/issues/2653#issuecomment-121997407