### PR TITLE
Compatibility with GHC 8.2

### DIFF
--- a/src/Pinch/Internal/Pinchable.hs
+++ b/src/Pinch/Internal/Pinchable.hs
@@ -122,12 +122,13 @@ class IsTType (Tag a) => Pinchable a where
     unpinch :: Value (Tag a) -> Parser a
 
     default pinch
-        :: (Generic a, GPinchable (Rep a)) => a -> Value (GTag (Rep a))
+        :: (Generic a, Tag a ~ GTag (Rep a), GPinchable (Rep a))
+        => a -> Value (Tag a)
     pinch = genericPinch
 
     default unpinch
-        :: (Generic a, GPinchable (Rep a))
-        => Value (GTag (Rep a)) -> Parser a
+        :: (Generic a, Tag a ~ GTag (Rep a), GPinchable (Rep a))
+        => Value (Tag a) -> Parser a
     unpinch = genericUnpinch
 
 


### PR DESCRIPTION
GHC 8.2 is a bit more strict about the the form of default signatures. Namely,
they may only differ from the type of the method they define in context.