### PR TITLE
Export decode with leftovers behavior

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-0.3.4.2 (2019-09-22)
+0.3.5.0 (2019-09-22)
 ====================
 
 -   Introduce decodeWithLeftovers for receiving unparsed portions

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+0.3.4.2 (2019-09-22)
+====================
+
+-   Introduce decodeWithLeftovers for receiving unparsed portions
+    of the provided bytestring.
+
 0.3.4.1 (2019-02-20)
 ====================
 

--- a/pinch.cabal
+++ b/pinch.cabal
@@ -5,7 +5,7 @@
 -- hash: a26aa0d54b7b1bd93ac84d5f821dcc0245b6df6ff10cb67dda63ee3f7f879551
 
 name:           pinch
-version:        0.3.4.2
+version:        0.3.5.0
 cabal-version:  >= 1.10
 build-type:     Simple
 license:        BSD3

--- a/pinch.cabal
+++ b/pinch.cabal
@@ -5,7 +5,7 @@
 -- hash: a26aa0d54b7b1bd93ac84d5f821dcc0245b6df6ff10cb67dda63ee3f7f879551
 
 name:           pinch
-version:        0.3.4.1
+version:        0.3.4.2
 cabal-version:  >= 1.10
 build-type:     Simple
 license:        BSD3

--- a/src/Pinch.hs
+++ b/src/Pinch.hs
@@ -209,7 +209,8 @@ decode :: Pinchable a => Protocol -> ByteString -> Either String a
 decode p = deserializeValue p >=> runParser . unpinch
 {-# INLINE decode #-}
 
--- | Decode a 'Pinchable' value from the using the given 'Protocol'.
+-- | Decode a 'Pinchable' value from the using the given 'Protocol'
+-- and also return the "unparsed" portion of the bytestring.
 --
 -- >>> let s = pack [11,0,0,0,2,0,0,0,1,97,0,0,0,1,98,0,0,0]
 -- >>> decodeWithLeftovers binaryProtocol s :: Either String [ByteString]

--- a/src/Pinch.hs
+++ b/src/Pinch.hs
@@ -19,6 +19,7 @@ module Pinch
 
       encode
     , decode
+    , decodeWithLeftovers
 
     -- * RPC
 
@@ -207,6 +208,16 @@ encode p = runBuilder . serializeValue p . pinch
 decode :: Pinchable a => Protocol -> ByteString -> Either String a
 decode p = deserializeValue p >=> runParser . unpinch
 {-# INLINE decode #-}
+
+-- | Decode a 'Pinchable' value from the using the given 'Protocol'.
+--
+-- >>> let s = pack [11,0,0,0,2,0,0,0,1,97,0,0,0,1,98,0,0,0]
+-- >>> decodeWithLeftovers binaryProtocol s :: Either String [ByteString]
+-- Right ("\NUL\NUL\NUL",["a","b"])
+--
+decodeWithLeftovers :: Pinchable a => Protocol -> ByteString -> Either String (ByteString, a)
+decodeWithLeftovers p = deserializeValue' p >=> traverse (runParser . unpinch)
+{-# INLINE decodeWithLeftovers #-}
 
 ------------------------------------------------------------------------------
 

--- a/src/Pinch.hs
+++ b/src/Pinch.hs
@@ -149,7 +149,7 @@ module Pinch
 
 import Control.Monad
 import Data.ByteString (ByteString)
-import Data.Int        (Int8, Int32)
+import Data.Int        (Int32)
 import Data.Text       (Text)
 
 import Pinch.Internal.Builder   (runBuilder)

--- a/src/Pinch.hs
+++ b/src/Pinch.hs
@@ -149,7 +149,7 @@ module Pinch
 
 import Control.Monad
 import Data.ByteString (ByteString)
-import Data.Int        (Int32)
+import Data.Int        (Int8, Int32)
 import Data.Text       (Text)
 
 import Pinch.Internal.Builder   (runBuilder)
@@ -212,9 +212,9 @@ decode p = deserializeValue p >=> runParser . unpinch
 -- | Decode a 'Pinchable' value from the using the given 'Protocol'
 -- and also return the "unparsed" portion of the bytestring.
 --
--- >>> let s = pack [11,0,0,0,2,0,0,0,1,97,0,0,0,1,98,0,0,0]
--- >>> decodeWithLeftovers binaryProtocol s :: Either String [ByteString]
--- Right ("\NUL\NUL\NUL",["a","b"])
+-- >>> let s = pack [3,0,0,0,5,1,2,3,4,5,0,0,0]
+-- >>> decodeWithLeftovers binaryProtocol s :: Either String (ByteString, [Int8])
+-- Right ("\NUL\NUL\NUL",[1,2,3,4,5])
 --
 decodeWithLeftovers :: Pinchable a => Protocol -> ByteString -> Either String (ByteString, a)
 decodeWithLeftovers p = deserializeValue' p >=> traverse (runParser . unpinch)

--- a/src/Pinch/Protocol.hs
+++ b/src/Pinch/Protocol.hs
@@ -14,7 +14,6 @@
 module Pinch.Protocol
     ( Protocol(..)
     , deserializeValue
-    , deserializeValue'
     ) where
 
 import Data.ByteString (ByteString)

--- a/src/Pinch/Protocol.hs
+++ b/src/Pinch/Protocol.hs
@@ -14,6 +14,7 @@
 module Pinch.Protocol
     ( Protocol(..)
     , deserializeValue
+    , deserializeValue'
     ) where
 
 import Data.ByteString (ByteString)


### PR DESCRIPTION
When users don't know the exact size of the value they want to parse, they might provide a larger bytestring than they actually need to.

This PR exports this behavior that already exists in Protocol.