### PR TITLE
Add Binary instances to Field and Enumeration types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+0.3.5.1 (2019-12-14)
+====================
+
+-   Add Binary instances to Field and Enumeration types.
+
 0.3.5.0 (2019-09-25)
 ====================
 

--- a/pinch.cabal
+++ b/pinch.cabal
@@ -51,6 +51,7 @@ library
     build-depends:
         array >=0.5,
         base >=4.7 && <5,
+        binary >=0.8 && <0.9,
         bytestring >=0.10 && <0.11,
         containers >=0.5 && <0.7,
         deepseq >=1.3 && <1.5,

--- a/src/Pinch/Internal/Generic.hs
+++ b/src/Pinch/Internal/Generic.hs
@@ -51,6 +51,7 @@ import Data.Foldable    (Foldable)
 import Data.Traversable (Traversable)
 #endif
 
+import Data.Binary         (Binary)
 import Data.Semigroup
 import Control.Applicative
 import Control.DeepSeq     (NFData)
@@ -128,7 +129,7 @@ instance
 newtype Field (n :: Nat) a = Field a
   deriving
     (Bounded, Eq, Enum, Foldable, Functor, Generic, Semigroup, Monoid, NFData, Ord, Show,
-     Traversable, Typeable)
+     Traversable, Typeable, Binary)
 
 -- | Gets the current value of a field.
 --
@@ -187,6 +188,7 @@ data Enumeration (n :: Nat) = Enumeration
     (Eq, Generic, Ord, Show, Typeable)
 
 instance NFData (Enumeration n)
+instance Binary (Enumeration k)
 
 -- | Convenience function to construct 'Enumeration' objects.
 --


### PR DESCRIPTION
Deriving `Binary` instance for `Field` and `Enumeration` types are almost trivial and creating instances as a pinch library user results in having orphan instances. This PR derives those instances.

An unrelated note: It looks like `pinch.cabal` is manually modified in one of the previous commits and results in a warning when running `stack repl`. I didn't fix it in this PR as it results in large unrelated diff. Let me know if you'd like it fixed though, I can open a separate PR for it.