### PR TITLE
Eta expand parseCatch

### DIFF
--- a/src/Pinch/Internal/Pinchable/Parser.hs
+++ b/src/Pinch/Internal/Pinchable/Parser.hs
@@ -89,5 +89,5 @@ runParser p = unParser p Left Right
 -- | Allows handling parse errors.
 parserCatch
     :: Parser a -> (String -> Parser b) -> (a -> Parser b) -> Parser b
-parserCatch = unParser
+parserCatch p f g = unParser p f g
 {-# INLINE parserCatch #-}


### PR DESCRIPTION
Required for compilation with GHC 9.0 due to simplified subsumption
proposal.