### PR TITLE
Add client/server support

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -50,16 +50,20 @@ library:
   source-dirs: src
   exposed-modules:
     - Pinch
+    - Pinch.Client
     - Pinch.Internal.Builder
+    - Pinch.Internal.Exception
     - Pinch.Internal.FoldList
     - Pinch.Internal.Generic
     - Pinch.Internal.Message
     - Pinch.Internal.Pinchable
+    - Pinch.Internal.RPC
     - Pinch.Internal.TType
     - Pinch.Internal.Value
     - Pinch.Protocol
     - Pinch.Protocol.Binary
     - Pinch.Protocol.Compact
+    - Pinch.Server
     - Pinch.Transport
   dependencies:
     - array >= 0.5
@@ -72,6 +76,8 @@ tests:
     main: Spec.hs
     source-dirs: tests
     dependencies:
+      - async >= 2.2.2 && < 2.3
       - hspec >= 2.0
+      - network-run >= 0.2.4 && < 0.3
       - pinch
       - QuickCheck >= 2.5

--- a/pinch.cabal
+++ b/pinch.cabal
@@ -46,16 +46,20 @@ source-repository head
 library
   exposed-modules:
       Pinch
+      Pinch.Client
       Pinch.Internal.Builder
+      Pinch.Internal.Exception
       Pinch.Internal.FoldList
       Pinch.Internal.Generic
       Pinch.Internal.Message
       Pinch.Internal.Pinchable
+      Pinch.Internal.RPC
       Pinch.Internal.TType
       Pinch.Internal.Value
       Pinch.Protocol
       Pinch.Protocol.Binary
       Pinch.Protocol.Compact
+      Pinch.Server
       Pinch.Transport
   other-modules:
       Pinch.Internal.Bits
@@ -87,6 +91,7 @@ test-suite pinch-spec
   main-is: Spec.hs
   other-modules:
       Pinch.Arbitrary
+      Pinch.ClientServerSpec
       Pinch.Expectations
       Pinch.Internal.BuilderParserSpec
       Pinch.Internal.BuilderSpec
@@ -107,12 +112,14 @@ test-suite pinch-spec
       hspec-discover:hspec-discover >=2.1
   build-depends:
       QuickCheck >=2.5
+    , async >=2.2.2 && <2.3
     , base >=4.7 && <5
     , bytestring >=0.10 && <0.11
     , cereal >=0.5.8.1 && <0.6
     , containers >=0.5 && <0.7
     , hspec >=2.0
     , network >=3.1 && <3.2
+    , network-run >=0.2.4 && <0.3
     , pinch
     , semigroups >=0.18 && <0.20
     , text >=1.2 && <1.3

--- a/src/Pinch/Client.hs
+++ b/src/Pinch/Client.hs
@@ -30,7 +30,7 @@ newtype Client = Client Channel
 data ThriftCall a where
   TCall :: (Pinchable req, Tag req ~ TStruct, Pinchable res, Tag res ~ TStruct)
     => !T.Text -> !req -> ThriftCall res
-  TOneway :: !T.Text -> !(Value TStruct) -> ThriftCall ()
+  TOneway :: (Pinchable req, Tag req ~ TStruct) => !T.Text -> !req -> ThriftCall ()
 
 -- | Calls a Thrift service and returns the result/error data structure.
 -- Application-level exceptions defined in the thrift service are returned

--- a/src/Pinch/Client.hs
+++ b/src/Pinch/Client.hs
@@ -30,19 +30,13 @@ newtype Client = Client Channel
 
 -- | A call to a Thrift server resulting in the return datatype `a`.
 data ThriftCall a where
-  TCall :: !T.Text -> !(Value TStruct) -> ThriftCall a
+  TCall :: (Pinchable a, Tag a ~ TStruct) => !T.Text -> !(Value TStruct) -> ThriftCall a
   TOneway :: !T.Text -> !(Value TStruct) -> ThriftCall ()
-
--- | An error occured while processing a thrift call.
--- Signals errors like premature EOF, Thrift protocol parsing failures etc.
-data ThriftError = ThriftError T.Text
-  deriving (Show, Eq)
-instance Exception ThriftError
 
 -- | Calls a Thrift service and returns the result/error data structure.
 -- Application-level exceptions defined in the thrift service are returned
 -- as part of the result/error data structure.
-call :: (Pinchable a, Tag a ~ TStruct) => Client -> ThriftCall a -> IO a
+call :: Client -> ThriftCall a -> IO a
 call (Client (Channel tIn tOut pIn pOut)) tcall = do
   case tcall of
     TOneway m r -> do

--- a/src/Pinch/Client.hs
+++ b/src/Pinch/Client.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+
+module Pinch.Client
+  ( Client
+  , ThriftCall(..)
+  , ThriftError(..)
+  , call
+  , simpleClient
+  ) where
+
+import           Control.Exception        (Exception, throwIO)
+
+import qualified Data.Text                as T
+
+import           Pinch.Internal.Exception
+import           Pinch.Internal.Message
+import           Pinch.Internal.Pinchable
+import           Pinch.Internal.RPC
+import           Pinch.Internal.TType
+import           Pinch.Internal.Value
+import           Pinch.Protocol
+import           Pinch.Transport
+
+-- | A simple Thrift Client.
+newtype Client = Client Channel
+
+-- | A call to a Thrift server resulting in the return datatype `a`.
+data ThriftCall a where
+  TCall :: !T.Text -> !(Value TStruct) -> ThriftCall a
+  TOneway :: !T.Text -> !(Value TStruct) -> ThriftCall ()
+
+-- | An error occured while processing a thrift call.
+-- Signals errors like premature EOF, Thrift protocol parsing failures etc.
+data ThriftError = ThriftError T.Text
+  deriving (Show, Eq)
+instance Exception ThriftError
+
+-- | Calls a Thrift service and returns the result/error data structure.
+-- Application-level exceptions defined in the thrift service are returned
+-- as part of the result/error data structure.
+call :: (Pinchable a, Tag a ~ TStruct) => Client -> ThriftCall a -> IO a
+call (Client (Channel tIn tOut pIn pOut)) tcall = do
+  case tcall of
+    TOneway m r -> do
+      writeMessage tOut $ serializeMessage pOut $ Message m Oneway 0 r
+      pure ()
+    TCall m r -> do
+      writeMessage tOut $ serializeMessage pOut $ Message m Call 0 r
+      reply <- readMessage tIn $ deserializeMessage' pIn
+      case reply of
+        RREOF -> throwIO $ ThriftError $ "Reached EOF while awaiting reply"
+        RRFailure err -> throwIO $ ThriftError $ "Could not read message: " <> T.pack err
+        RRSuccess reply -> case messageType reply of
+          Reply -> case runParser $ unpinch $ messagePayload reply of
+            Right x -> pure x
+            Left err -> do
+              throwIO $ ThriftError $ "Could not parse reply payload: " <> T.pack err
+          Exception -> case runParser $ unpinch $ messagePayload reply of
+            Right (x :: ApplicationException) -> throwIO x
+            Left err ->
+              throwIO $ ThriftError $ "Could not parse application exception: " <> T.pack err
+          t -> throwIO $ ThriftError $ "Expected reply or exception, got " <> T.pack (show t) <> "."
+
+-- | Instantiates a new Thrift client.
+simpleClient :: Channel -> Client
+simpleClient = Client

--- a/src/Pinch/Internal/Exception.hs
+++ b/src/Pinch/Internal/Exception.hs
@@ -17,6 +17,7 @@ import           Pinch.Internal.TType
 
 import qualified Data.Text                as T
 
+-- | Thrift application exception as defined in <https://github.com/apache/thrift/blob/master/doc/specs/thrift-rpc.md#response-struct>.
 data ApplicationException
   = ApplicationException
   { appExMessage :: T.Text
@@ -38,18 +39,20 @@ instance Pinchable ApplicationException where
     <$> value .: 1
     <*> value .: 2
 
+-- | Thrift exception type as defined in <https://github.com/apache/thrift/blob/master/doc/specs/thrift-rpc.md#response-struct>.
 data ExceptionType
-  = Unknown
-  | UnknownMethod
-  | InvalidMessageType
-  | WrongMethodName
-  | BadSequenceId
-  | MissingResult
-  | InternalError
-  | ProtocolError
-  | InvalidTransform
-  | InvalidProtocol
-  | UnsupportedClientType
+  -- DO NOT RE-ORDER, the enum values need to match the ones defined in the Thrift specification!
+  = Unknown               -- 0
+  | UnknownMethod         -- 1
+  | InvalidMessageType    -- 2
+  | WrongMethodName       -- 3
+  | BadSequenceId         -- 4
+  | MissingResult         -- 5
+  | InternalError         -- 6
+  | ProtocolError         -- 7
+  | InvalidTransform      -- 8
+  | InvalidProtocol       -- 9
+  | UnsupportedClientType -- 10
   deriving (Show, Eq, Enum, Bounded)
 
 instance Pinchable ExceptionType where

--- a/src/Pinch/Internal/Exception.hs
+++ b/src/Pinch/Internal/Exception.hs
@@ -5,6 +5,7 @@
 module Pinch.Internal.Exception
   ( ApplicationException (..)
   , ExceptionType (..)
+  , ThriftError(..)
   )
 where
 
@@ -61,3 +62,9 @@ instance Pinchable ExceptionType where
     if (fromEnum $ minBound @ExceptionType) <= value && value <= (fromEnum $ maxBound @ExceptionType)
       then pure $ toEnum $ fromIntegral value
       else fail $ "Unknown application exception type: " ++ show value
+
+-- | An error occured while processing a thrift call.
+-- Signals errors like premature EOF, Thrift protocol parsing failures etc.
+data ThriftError = ThriftError T.Text
+  deriving (Show, Eq)
+instance Exception ThriftError

--- a/src/Pinch/Internal/Exception.hs
+++ b/src/Pinch/Internal/Exception.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
+
+module Pinch.Internal.Exception
+  ( ApplicationException (..)
+  , ExceptionType (..)
+  )
+where
+
+import           Control.Exception        (Exception)
+import           Data.Int
+import           Data.Typeable            (Typeable)
+import           Pinch.Internal.Pinchable
+import           Pinch.Internal.TType
+
+import qualified Data.Text                as T
+
+data ApplicationException
+  = ApplicationException
+  { appExMessage :: T.Text
+  , appExType    :: ExceptionType
+  }
+  deriving (Show, Eq, Typeable)
+
+instance Exception ApplicationException
+
+instance Pinchable ApplicationException where
+  type Tag ApplicationException = TStruct
+
+  pinch p = struct
+    [ 1 .= appExMessage p
+    , 2 .= appExType p
+    ]
+
+  unpinch value = ApplicationException
+    <$> value .: 1
+    <*> value .: 2
+
+data ExceptionType
+  = Unknown
+  | UnknownMethod
+  | InvalidMessageType
+  | WrongMethodName
+  | BadSequenceId
+  | MissingResult
+  | InternalError
+  | ProtocolError
+  | InvalidTransform
+  | InvalidProtocol
+  | UnsupportedClientType
+  deriving (Show, Eq, Enum, Bounded)
+
+instance Pinchable ExceptionType where
+  type Tag ExceptionType = TEnum
+
+  pinch t = pinch ((fromIntegral $ fromEnum t) :: Int32)
+
+  unpinch v = do
+    value <- (fromIntegral :: Int32 -> Int) <$> unpinch v
+    if (fromEnum $ minBound @ExceptionType) <= value && value <= (fromEnum $ maxBound @ExceptionType)
+      then pure $ toEnum $ fromIntegral value
+      else fail $ "Unknown application exception type: " ++ show value

--- a/src/Pinch/Internal/RPC.hs
+++ b/src/Pinch/Internal/RPC.hs
@@ -5,19 +5,17 @@ module Pinch.Internal.RPC
   ( Channel(..)
   , createChannel
   , createChannel1
+  , readMessage
+  , writeMessage
+
+  , ReadResult(..)
   ) where
 
+import           Pinch.Internal.Message
+import           Pinch.Protocol       (Protocol, deserializeMessage', serializeMessage)
+import           Pinch.Transport      (Connection, Transport, ReadResult(..))
 
-import           Data.Hashable        (Hashable)
-import           Data.Text            (Text)
-
-import qualified Data.HashMap.Strict  as HM
-import qualified Data.Text            as T
-
-import           Pinch.Internal.TType
-import           Pinch.Internal.Value
-import           Pinch.Protocol       (Protocol)
-import           Pinch.Transport      (Connection, Transport)
+import qualified Pinch.Transport      as Transport
 
 -- | A bi-directional channel to read/write Thrift messages.
 data Channel = Channel
@@ -36,3 +34,9 @@ createChannel c t p = do
 -- | Creates a channel.
 createChannel1 :: (Transport, Protocol) -> (Transport, Protocol) -> Channel
 createChannel1 (tIn, pIn) (tOut, pOut) = Channel tIn tOut pIn pOut
+
+readMessage :: Channel -> IO (ReadResult Message)
+readMessage chan = Transport.readMessage (cTransportIn chan) $ deserializeMessage' (cProtocolIn chan)
+
+writeMessage :: Channel -> Message -> IO ()
+writeMessage chan msg = Transport.writeMessage (cTransportOut chan) $ serializeMessage (cProtocolOut chan) msg

--- a/src/Pinch/Internal/RPC.hs
+++ b/src/Pinch/Internal/RPC.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE ExistentialQuantification  #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeFamilies               #-}
+module Pinch.Internal.RPC
+  ( Channel(..)
+  , createChannel
+  , createChannel1
+  ) where
+
+
+import           Data.Hashable        (Hashable)
+import           Data.Text            (Text)
+
+import qualified Data.HashMap.Strict  as HM
+import qualified Data.Text            as T
+
+import           Pinch.Internal.TType
+import           Pinch.Internal.Value
+import           Pinch.Protocol       (Protocol)
+import           Pinch.Transport      (Connection, Transport)
+
+-- | A bi-directional channel to read/write Thrift messages.
+data Channel = Channel
+  { cTransportIn  :: !Transport
+  , cTransportOut :: !Transport
+  , cProtocolIn   :: !Protocol
+  , cProtocolOut  :: !Protocol
+  }
+
+-- | Creates a channel using the same transport/protocol for both directions.
+createChannel :: Connection c => c -> (c -> IO Transport) -> Protocol -> IO Channel
+createChannel c t p = do
+  t' <- t c
+  pure $ Channel t' t' p p
+
+-- | Creates a channel.
+createChannel1 :: (Transport, Protocol) -> (Transport, Protocol) -> Channel
+createChannel1 (tIn, pIn) (tOut, pOut) = Channel tIn tOut pIn pOut

--- a/src/Pinch/Server.hs
+++ b/src/Pinch/Server.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE OverloadedStrings         #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE TypeApplications          #-}
+{-# LANGUAGE TypeFamilies              #-}
+
+module Pinch.Server
+  ( ThriftServer(..)
+  , ParseError (..)
+  , Channel (..)
+  , Context
+  , ContextItem (..)
+  , addToContext
+  , lookupInContext
+
+  , createServer
+  , runConnection
+  ) where
+
+
+import           Control.Concurrent       (forkFinally)
+import           Control.Exception        (Exception, SomeException, throwIO,
+                                           try)
+import           Control.Monad
+import           Data.Dynamic             (Dynamic (..), fromDynamic, toDyn)
+import           Data.Proxy               (Proxy (..))
+import           Data.Typeable            (TypeRep, Typeable, typeOf, typeRep)
+
+import qualified Data.HashMap.Strict      as HM
+import qualified Data.Text                as T
+
+import           Pinch.Internal.Exception
+import           Pinch.Internal.Message
+import           Pinch.Internal.Pinchable
+import           Pinch.Internal.RPC
+import           Pinch.Internal.TType
+
+import qualified Pinch.Protocol           as P
+import qualified Pinch.Transport          as T
+
+-- | A `Thrift` server. Takes the context and the request message as input and produces a reply message.
+newtype ThriftServer = ThriftServer { unThriftServer :: Context -> Message -> IO Message }
+
+data ParseError = ParseError T.Text
+  deriving (Show, Eq)
+instance Exception ParseError
+
+-- | Allows passing context information to a `ThriftServer`.
+-- The context is indexed by type.
+newtype Context = Context (HM.HashMap TypeRep Dynamic)
+
+class Typeable a => ContextItem a where
+
+instance Semigroup Context where
+  (Context a) <> (Context b) = Context $ a <> b
+
+instance Monoid Context where
+  mempty = Context mempty
+
+
+-- | Adds a new item to the context. If an item with the same
+-- type is already part of the context, it will be overwritten.
+addToContext :: forall i . ContextItem i => i -> Context -> Context
+addToContext i (Context m) =
+  Context $ HM.insert (typeOf i) (toDyn i) m
+
+-- | Lookup a value in the context.
+lookupInContext :: forall i . ContextItem i => Context -> Maybe i
+lookupInContext (Context m) = do
+  x <- HM.lookup (typeRep (Proxy :: Proxy i)) m
+  case fromDynamic @i x of
+    Nothing -> error "Impossible!"
+    Just y  -> pure y
+
+
+-- | Creates a new thrift server processing requests with the function `f`.
+createServer :: (Pinchable c, Pinchable r, Tag c ~ TStruct, Tag r ~ TStruct) => (Context -> T.Text -> c -> IO r) -> ThriftServer
+createServer f = ThriftServer $ \ctx msg -> do
+  case runParser $ unpinch $ messagePayload msg of
+    Right args -> do
+      ret <- f ctx (messageName msg) args
+      pure $ Message
+        { messageName = messageName msg
+        , messageType = Reply
+        , messageId   = messageId msg
+        , messagePayload = pinch ret
+        }
+    Left err -> do
+      pure $ msgAppEx msg $ ApplicationException ("Unable to parse service arguments: " <> T.pack err) InternalError
+
+-- | Run a Thrift server for a single connection.
+runConnection :: Context -> ThriftServer -> Channel -> IO ()
+runConnection ctx srv chan = do
+  msg <- T.readMessage (cTransportIn chan) $ P.deserializeMessage' (cProtocolIn chan)
+  case msg of
+    T.RREOF -> pure ()
+    T.RRFailure err -> do
+      throwIO $ ParseError $ T.pack err
+    T.RRSuccess call -> do
+      reply <- case messageType call of
+        Call -> do
+          r <- try $ unThriftServer srv ctx call
+          case r of
+            Left (e :: SomeException) -> pure $ msgAppEx call $
+              ApplicationException ("Could not process request: " <> (T.pack $ show e)) InternalError
+            Right x -> pure x
+        t -> pure $ msgAppEx call $ ApplicationException ("Expected call, got " <> (T.pack $ show t)) InvalidMessageType
+      T.writeMessage (cTransportOut chan) $ P.serializeMessage (cProtocolOut chan) reply
+      runConnection ctx srv chan
+  where
+
+msgAppEx :: Message -> ApplicationException -> Message
+msgAppEx req ex = Message
+  { messageName = messageName req
+  , messageType = Exception
+  , messageId = messageId req
+  , messagePayload = pinch ex
+  }

--- a/tests/Pinch/ClientServerSpec.hs
+++ b/tests/Pinch/ClientServerSpec.hs
@@ -1,0 +1,126 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Pinch.ClientServerSpec (spec) where
+
+import           Control.Concurrent       (forkFinally, threadDelay)
+import           Control.Concurrent.Async (withAsync)
+import           Control.Exception        (bracket, bracketOnError, finally)
+import           Control.Monad            (forever, void)
+import           Data.ByteString          (ByteString)
+import           Data.Int
+import           Data.IORef               (IORef, modifyIORef, newIORef,
+                                           readIORef, writeIORef)
+import           Data.Text                (Text)
+import           GHC.Generics             (Generic)
+import           Network.Run.TCP          (runTCPClient)
+import           Network.Socket
+import           Test.Hspec
+import           Test.Hspec.QuickCheck
+import           Test.QuickCheck
+
+import qualified Data.ByteString          as BS
+import qualified Data.Serialize.Get       as G
+
+import           Pinch
+import           Pinch.Arbitrary          (SomeByteString (..))
+import           Pinch.Client
+import           Pinch.Internal.Message
+import           Pinch.Internal.RPC
+import           Pinch.Protocol
+import           Pinch.Server
+import           Pinch.Transport
+
+echoServer :: ThriftServer
+echoServer = createServer $ \_ _ (r :: Value TStruct) ->
+  pure r
+
+data CalcRequest = CalcRequest
+  { inp1 :: Field 1 Int32
+  , inp2 :: Field 2 Int32
+  , op   :: Field 3 Op
+  } deriving (Generic, Show)
+instance Pinchable CalcRequest
+
+data Op = Plus (Enumeration 1) | Minus (Enumeration 2) | Div (Enumeration 3)
+  deriving (Generic, Show)
+instance Pinchable Op
+
+data CalcResult = CalcResult
+  { result :: Field 1 (Maybe Int32)
+  , error  :: Field 2 (Maybe Text)
+  } deriving (Generic, Show, Eq)
+instance Pinchable CalcResult
+
+calcServer :: ThriftServer
+calcServer = createServer $ \_ _ r@(CalcRequest (Field inp1) (Field inp2) (Field op)) -> do
+  let ret = case op of
+        Plus _ -> CalcResult (Field $ Just $ inp1 + inp2) (Field Nothing)
+        Minus _ -> CalcResult (Field $ Just $ inp1 - inp2) (Field Nothing)
+        Div _ | inp2 == 0 -> CalcResult (Field Nothing) (Field $ Just "div by zero")
+        Div _ -> CalcResult (Field $ Just $ inp1 `div` inp2) (Field Nothing)
+  pure ret
+
+
+spec :: Spec
+spec = do
+  describe "Client/Server" $ do
+    prop "echo test" $ withMaxSuccess 10 $ \request -> ioProperty $
+      withLoopbackServer echoServer $ \client -> do
+        reply <- call client $ TCall "" request
+        pure $
+          reply === request
+
+    it "calculator" $ do
+      withLoopbackServer calcServer $ \client -> do
+        r1 <- call client $ mkCall 10 20 Plus
+        r1 `shouldBe` CalcResult (Field $ Just 30) (Field Nothing)
+
+        r2 <- call client $ mkCall 10 20 Minus
+        r2 `shouldBe` CalcResult (Field $ Just $ -10) (Field Nothing)
+
+        r3 <- call client $ mkCall 20 10 Div
+        r3 `shouldBe` CalcResult (Field $ Just 2) (Field Nothing)
+
+        r4 <- call client $ mkCall 10 0 Div
+        r4 `shouldBe` CalcResult (Field Nothing) (Field $ Just "div by zero")
+  where
+    mkCall inp1 inp2 op = TCall "calc" $ pinch $ CalcRequest (Field inp1) (Field inp2) (Field $ op $ Enumeration)
+
+
+withLoopbackServer :: ThriftServer -> (Client -> IO a) -> IO a
+withLoopbackServer srv cont = do
+    addr <- resolve Stream (Just "127.0.0.1") "54093" True
+    bracketOnError (open addr) close (\sock ->
+      withAsync (loop sock `finally` close sock) $ \_ ->
+        runTCPClient "127.0.0.1" "54093" $ \s -> do
+          client <- simpleClient <$> createChannel s framedTransport binaryProtocol
+          cont client
+      )
+  where
+    open addr = bracketOnError (openServerSocket addr) close $ \sock -> do
+        listen sock 1024
+        return sock
+    loop sock = forever $ bracketOnError (accept sock) (close . fst) $
+        \(conn, _peer) ->
+          void $ forkFinally (runServer conn) (const $ gracefulClose conn 5000)
+    runServer sock = do
+      createChannel sock framedTransport binaryProtocol
+        >>= runConnection mempty srv
+
+    resolve :: SocketType -> Maybe HostName -> ServiceName -> Bool -> IO AddrInfo
+    resolve socketType mhost port passive =
+        head <$> getAddrInfo (Just hints) mhost (Just port)
+      where
+        hints = defaultHints
+          { addrSocketType = socketType
+          , addrFlags = if passive then [AI_PASSIVE] else []
+          }
+    openServerSocket :: AddrInfo -> IO Socket
+    openServerSocket addr = bracketOnError (openSocket addr) close $ \sock -> do
+      setSocketOption sock ReuseAddr 1
+      withFdSocket sock $ setCloseOnExecIfNeeded
+      bind sock $ addrAddress addr
+      return sock


### PR DESCRIPTION
Allows creating Thrift servers/clients. This does not yet involve any code generation, but just assumes that there are suitable datatypes/pinchable instances either defined manually or using the automatically derived pinchable instances.

On the server side, it features a `Context` facility which allows passing through information to the server. I found this quite useful, e.g. one can pass in the socket that way and add a custom error handler logging the remote ip/port.

This PR also adds a dependency on `async` and `network-run`, but only does so for the test-suite. Async is used to ensure that we properly cleanup the server after the test.