### PR TITLE
Server-side multiplex support

### DIFF
--- a/src/Pinch/Internal/RPC.hs
+++ b/src/Pinch/Internal/RPC.hs
@@ -9,13 +9,22 @@ module Pinch.Internal.RPC
   , writeMessage
 
   , ReadResult(..)
+
+  , ServiceName(..)
   ) where
 
-import           Pinch.Internal.Message
-import           Pinch.Protocol       (Protocol, deserializeMessage', serializeMessage)
-import           Pinch.Transport      (Connection, Transport, ReadResult(..))
+import           Data.Hashable          (Hashable (..))
+import           Data.String            (IsString (..))
+import           Data.Typeable          (Typeable)
 
-import qualified Pinch.Transport      as Transport
+import qualified Data.Text              as T
+
+import           Pinch.Internal.Message
+import           Pinch.Protocol         (Protocol, deserializeMessage',
+                                         serializeMessage)
+import           Pinch.Transport        (Connection, ReadResult (..), Transport)
+
+import qualified Pinch.Transport        as Transport
 
 -- | A bi-directional channel to read/write Thrift messages.
 data Channel = Channel
@@ -40,3 +49,10 @@ readMessage chan = Transport.readMessage (cTransportIn chan) $ deserializeMessag
 
 writeMessage :: Channel -> Message -> IO ()
 writeMessage chan msg = Transport.writeMessage (cTransportOut chan) $ serializeMessage (cProtocolOut chan) msg
+
+
+newtype ServiceName = ServiceName T.Text
+  deriving (Typeable, Eq, Hashable)
+
+instance IsString ServiceName where
+  fromString = ServiceName . T.pack

--- a/tests/Pinch/ClientServerSpec.hs
+++ b/tests/Pinch/ClientServerSpec.hs
@@ -16,7 +16,7 @@ import           Data.Int
 import           Data.Text                (Text)
 import           GHC.Generics             (Generic)
 import           Network.Run.TCP          (runTCPClient)
-import           Network.Socket
+import           Network.Socket           as S
 import           Test.Hspec
 import           Test.Hspec.QuickCheck
 import           Test.QuickCheck
@@ -126,7 +126,7 @@ withLoopbackServer srv cont = do
       createChannel sock framedTransport binaryProtocol
         >>= runConnection mempty srv
 
-    resolve :: SocketType -> Maybe HostName -> ServiceName -> Bool -> IO AddrInfo
+    resolve :: SocketType -> Maybe HostName -> S.ServiceName -> Bool -> IO AddrInfo
     resolve socketType mhost port passive =
         head <$> getAddrInfo (Just hints) mhost (Just port)
       where


### PR DESCRIPTION
Uses a hash map internally to lookup the correct service. As the service name is not part of the *.thrift file, I think it makes sense to just use a manually constructed mapping.