### PR TITLE
Use new header format for binary protocol

### DIFF
--- a/src/Pinch/Protocol/Binary.hs
+++ b/src/Pinch/Protocol/Binary.hs
@@ -54,8 +54,12 @@ binaryProtocol = Protocol
 
 binarySerializeMessage :: Message -> Builder
 binarySerializeMessage msg =
+    BB.word8 0x80 <>
+    BB.word8 0x01 <>
+    BB.word8 0x00 <>
+    BB.int8 (messageCode $ messageType msg) <>
     string (TE.encodeUtf8 $ messageName msg) <>
-    BB.int8 (messageCode (messageType msg)) <> BB.int32BE (messageId msg) <>
+    BB.int32BE (messageId msg) <>
     binarySerialize (messagePayload msg)
 
 binaryDeserializeMessage :: G.Get Message

--- a/tests/Pinch/Protocol/BinarySpec.hs
+++ b/tests/Pinch/Protocol/BinarySpec.hs
@@ -273,7 +273,7 @@ spec = describe "BinaryProtocol" $ do
         , (SomeTType TList, [0x10, 0x00, 0x00, 0x00, 0x00])
         ]
 
-    it "can read and write messages" $ readWriteMessageCases
+    it "can read and write messages" $ readMessageCases
         [ ([ 0x00, 0x00, 0x00, 0x06                 -- length = 6
            , 0x67, 0x65, 0x74, 0x46, 0x6f, 0x6f     -- 'getFoo'
            , 0x01                                   -- type = Call
@@ -288,7 +288,7 @@ spec = describe "BinaryProtocol" $ do
            ], Message "setBar" Reply 1 (vstruct []))
         ]
 
-    it "can read strict messages" $ readMessageCases
+    it "can read strict messages" $ readWriteMessageCases
         [ ([ 0x80, 0x01     -- version = 1
            , 0x00, 0x03     -- type = Exception
 


### PR DESCRIPTION
Using the old header format we had some compatibility issues with a java/python library. I think there should be no drawback to serialize to the new header format.