### PR TITLE
Add way to extract result/exceptions from thrift calls more easily

### DIFF
--- a/src/Pinch/Client.hs
+++ b/src/Pinch/Client.hs
@@ -9,6 +9,7 @@ module Pinch.Client
   , ThriftCall(..)
   , ThriftError(..)
   , call
+  , callOrThrow
   , simpleClient
   ) where
 
@@ -21,7 +22,6 @@ import           Pinch.Internal.Message
 import           Pinch.Internal.Pinchable
 import           Pinch.Internal.RPC
 import           Pinch.Internal.TType
-import           Pinch.Internal.Value
 
 -- | A simple Thrift Client.
 newtype Client = Client Channel
@@ -57,6 +57,11 @@ call (Client chan) tcall = do
             Left err ->
               throwIO $ ThriftError $ "Could not parse application exception: " <> T.pack err
           t -> throwIO $ ThriftError $ "Expected reply or exception, got " <> T.pack (show t) <> "."
+
+-- | Calls a Thrift service. If an application-level thrift exception as defined in the Thrift service definition
+-- is returned by the server, it will be re-thrown using `throwIO`.
+callOrThrow :: ThriftResult a => Client -> ThriftCall a -> IO (ResultType a)
+callOrThrow client c = call client c >>= unwrap
 
 -- | Instantiates a new Thrift client.
 simpleClient :: Channel -> Client

--- a/src/Pinch/Internal/RPC.hs
+++ b/src/Pinch/Internal/RPC.hs
@@ -9,13 +9,19 @@ module Pinch.Internal.RPC
   , writeMessage
 
   , ReadResult(..)
+
+  , ThriftResult(..)
   ) where
 
 import           Pinch.Internal.Message
-import           Pinch.Protocol       (Protocol, deserializeMessage', serializeMessage)
-import           Pinch.Transport      (Connection, Transport, ReadResult(..))
+import           Pinch.Internal.Pinchable (Pinchable, Tag)
+import           Pinch.Internal.TType     (TStruct)
+import           Pinch.Protocol           (Protocol, deserializeMessage',
+                                           serializeMessage)
+import           Pinch.Transport          (Connection, ReadResult (..),
+                                           Transport)
 
-import qualified Pinch.Transport      as Transport
+import qualified Pinch.Transport          as Transport
 
 -- | A bi-directional channel to read/write Thrift messages.
 data Channel = Channel
@@ -40,3 +46,12 @@ readMessage chan = Transport.readMessage (cTransportIn chan) $ deserializeMessag
 
 writeMessage :: Channel -> Message -> IO ()
 writeMessage chan msg = Transport.writeMessage (cTransportOut chan) $ serializeMessage (cProtocolOut chan) msg
+
+-- | The Result datatype for a Thrift Service Method.
+class (Pinchable a, Tag a ~ TStruct) => ThriftResult a where
+  -- | The Haskell type returned when the Thrift call succeeds.
+  type ResultType a
+  -- | Tries to extract the result from a Thrift call. If the call threw any
+  -- of the Thrift exceptions declared for this Thrift service method,
+  -- the corresponding Haskell excpetions is thrown using `throwIO`.
+  unwrap :: a -> IO (ResultType a)


### PR DESCRIPTION
This class is mostly useful together with the code generator, as it will generate the class instances for the result datatypes automatically.

The class is in the RPC module as I plan to add another function which goes the opposite direction (SomeException -> Result datatype) for the server side.