### PR TITLE
Wrap method / Unit datatype

### DIFF
--- a/src/Pinch/Internal/RPC.hs
+++ b/src/Pinch/Internal/RPC.hs
@@ -70,3 +70,8 @@ class (Pinchable a, Tag a ~ TStruct) => ThriftResult a where
   -- of the Thrift exceptions declared for this Thrift service method,
   -- the corresponding Haskell excpetions is thrown using `throwIO`.
   unwrap :: a -> IO (ResultType a)
+
+  -- | Runs the given computation. If it throws any of the exceptions
+  -- declared in the Thrift service definition, it is caught and converted
+  -- to the corresponding Haskell result datatype constructor.
+  wrap :: IO (ResultType a) -> IO a

--- a/src/Pinch/Internal/RPC.hs
+++ b/src/Pinch/Internal/RPC.hs
@@ -12,17 +12,21 @@ module Pinch.Internal.RPC
 
   , ServiceName(..)
   , ThriftResult(..)
+
+  , Unit(..)
   ) where
 
 import           Data.Hashable            (Hashable (..))
 import           Data.String              (IsString (..))
 import           Data.Typeable            (Typeable)
 
+import qualified Data.HashMap.Strict      as HM
 import qualified Data.Text                as T
 
 import           Pinch.Internal.Message
-import           Pinch.Internal.Pinchable (Pinchable, Tag)
+import           Pinch.Internal.Pinchable (Pinchable (..), Tag)
 import           Pinch.Internal.TType     (TStruct)
+import           Pinch.Internal.Value     (Value (..))
 import           Pinch.Protocol           (Protocol, deserializeMessage',
                                            serializeMessage)
 import           Pinch.Transport          (Connection, ReadResult (..),
@@ -75,3 +79,17 @@ class (Pinchable a, Tag a ~ TStruct) => ThriftResult a where
   -- declared in the Thrift service definition, it is caught and converted
   -- to the corresponding Haskell result datatype constructor.
   wrap :: IO (ResultType a) -> IO a
+
+-- | Result datatype for void methods not throwing any exceptions.
+data Unit = Unit
+
+instance Pinchable Unit where
+  type Tag Unit = TStruct
+  pinch Unit = VStruct mempty
+  unpinch (VStruct xs) | HM.null xs = pure Unit
+  unpinch x            = fail $ "Failed to read void success. Got " ++ show x
+
+instance ThriftResult Unit where
+  type ResultType Unit = ()
+  wrap m = Unit <$ m
+  unwrap Unit = pure ()


### PR DESCRIPTION
Last bits needed for the code generator. Wrap is used to catch exceptions and converting them to the appropriate result datatype. The `Unit` datatype is used for all void methods with no exceptions, as the generated result datatype would be structurally the same for all such methods.