### PR TITLE
Terminate connection if client sends wrong message type

### DIFF
--- a/src/Pinch/Server.hs
+++ b/src/Pinch/Server.hs
@@ -238,7 +238,8 @@ runConnection ctx srv chan = do
           -- Let's just crash the connection in this case, to avoid silently swallowing errors.
           -- `onError` can be used to handle this more gracefully.
           unThriftServer srv ctx (ROneway call)
-        t -> writeMessage chan $ mkApplicationExceptionReply call $
+        -- the client must never send Reply/Exception messages.
+        t -> throwIO $
           ApplicationException ("Expected call, got " <> (T.pack $ show t)) InvalidMessageType
       runConnection ctx srv chan
 


### PR DESCRIPTION
A client must never send any Reply/Exception messages.