### PR TITLE
Bump the lower bound for `network`

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -39,7 +39,7 @@ dependencies:
   - bytestring >= 0.10 && < 0.12
   - cereal >= 0.5.8.1 && < 0.6
   - containers >= 0.5 && < 0.7
-  - network >= 3.1 && < 3.2
+  - network >= 3.1.2.0 && < 3.2
   - text >= 1.2 && < 1.3
   - unordered-containers >= 0.2 && < 0.3
   - vector >= 0.10 && < 0.13

--- a/pinch.cabal
+++ b/pinch.cabal
@@ -81,7 +81,7 @@ library
     , deepseq >=1.3 && <1.5
     , ghc-prim
     , hashable >=1.2 && <1.4
-    , network ==3.1.*
+    , network >=3.1.2.0 && <3.2
     , semigroups >=0.18 && <0.21
     , text ==1.2.*
     , unordered-containers ==0.2.*
@@ -120,7 +120,7 @@ test-suite pinch-spec
     , cereal >=0.5.8.1 && <0.6
     , containers >=0.5 && <0.7
     , hspec >=2.0
-    , network ==3.1.*
+    , network >=3.1.2.0 && <3.2
     , network-run >=0.2.4 && <0.3
     , pinch
     , semigroups >=0.18 && <0.21


### PR DESCRIPTION
I noticed `pinch` was marked as broken on nixpkgs and so looking into it I
realized `network`'s version was at 3.1.1.1 which doesn't have this function
called `openSocket` that's used in `pinch`'s test suite.

While this update won't be a fix for nixpkgs it makes sense updating the lower
bound to make sure `pinch` can't use a  version of `network` without
`openSocket`.