### PR TITLE
Bump upper bound of hashable

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -71,7 +71,7 @@ library:
     - array >= 0.5
     - deepseq >= 1.3 && < 1.5
     - ghc-prim
-    - hashable >= 1.2 && < 1.4
+    - hashable >= 1.2 && < 1.5
 
 tests:
   pinch-spec:


### PR DESCRIPTION
Seems like this builds fine for me on Stackage nightly, so it might just be a matter of revising Hackage metadata

Allows reenabling `pinch` on Stackage: https://github.com/commercialhaskell/stackage/blob/5e2fce2ad4a0343a04ccadf3ec6c2495076e39de/build-constraints.yaml#L6857