### PR TITLE
ci: Only test on Linux

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,13 +6,9 @@ jobs:
     strategy:
       matrix:
         ghc: ['8.4.4', '8.6.5', '8.8.3', '8.10.2', '9.0.1', '9.2.1']
-        os: [ubuntu-latest, macOS-latest, windows-latest]
-        exclude:
-          # a test suite dependency fails on windows/ghc8.8.3
-          - os: windows-latest
-            ghc: '8.8.3'
+        os: [ubuntu-latest]
       fail-fast: false
-    name: Build with GHC ${{ matrix.ghc }} on ${{ matrix.os }}
+    name: GHC ${{ matrix.ghc }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup Haskell


### PR DESCRIPTION
All the additional Windows/macOS checks
are redundant.
We don't have any platform specific code.