### PR TITLE
Allow vector-0.13

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -42,7 +42,7 @@ dependencies:
   - network >= 3.1.2.0 && < 3.2
   - text >= 1.2 && < 1.3 || >= 2.0
   - unordered-containers >= 0.2 && < 0.3
-  - vector >= 0.10 && < 0.13
+  - vector >= 0.10 && < 0.14
   - semigroups >= 0.18 && < 0.21
 
 build-tools:

--- a/pinch.cabal
+++ b/pinch.cabal
@@ -85,7 +85,7 @@ library
     , semigroups >=0.18 && <0.21
     , text >=1.2 && <1.3 || >=2.0
     , unordered-containers ==0.2.*
-    , vector >=0.10 && <0.13
+    , vector >=0.10 && <0.14
   default-language: Haskell2010
 
 test-suite pinch-spec
@@ -126,5 +126,5 @@ test-suite pinch-spec
     , semigroups >=0.18 && <0.21
     , text >=1.2 && <1.3 || >=2.0
     , unordered-containers ==0.2.*
-    , vector >=0.10 && <0.13
+    , vector >=0.10 && <0.14
   default-language: Haskell2010


### PR DESCRIPTION
Closes #52. Passed the test suite on GHC 9.2.7 with the constraint on vector set.