### PR TITLE
Connections can select their preferred read size

### DIFF
--- a/src/Pinch/Transport.hs
+++ b/src/Pinch/Transport.hs
@@ -78,12 +78,10 @@ unframedTransport c = do
     writeMsg msg = cPut c $ B.runBuilder msg
 
     readMsg buf p = do
-      bs <- readIORef buf
-      bs' <- if BS.null bs then getSome else pure bs
-      (leftOvers, r) <- runGetWith getSome p bs'
-      writeIORef buf leftOvers
-      pure $ r
-    getSome = cGetSome c
+      initial <- readIORef buf
+      (leftovers, r) <- runGetWith (cGetSome c) p initial
+      writeIORef buf $! leftovers
+      pure r
 
 -- | Runs a Get parser incrementally, reading more input as necessary until a successful parse
 -- has been achieved.

--- a/src/Pinch/Transport.hs
+++ b/src/Pinch/Transport.hs
@@ -19,7 +19,7 @@ import qualified Data.Serialize.Get as G
 import qualified Pinch.Internal.Builder as B
 
 class Connection c where
-  -- | Gets up to n bytes. Returns an empty bytestring if EOF is reached.
+  -- | Returns available bytes, or an empty bytestring if EOF was reached.
   cGetSome :: c -> IO BS.ByteString
   -- | Writes the given bytestring.
   cPut :: c -> BS.ByteString -> IO ()

--- a/tests/Pinch/TransportSpec.hs
+++ b/tests/Pinch/TransportSpec.hs
@@ -29,9 +29,9 @@ mGetContents :: MemoryConnection -> IO ByteString
 mGetContents = readIORef . contents
 
 instance Connection MemoryConnection where
-  cGetSome (MemoryConnection ref ch) n = do
+  cGetSome (MemoryConnection ref ch) = do
     bytes <- readIORef ref
-    let (left, right) = BS.splitAt (min ch n) bytes
+    let (left, right) = BS.splitAt ch bytes
     writeIORef ref right
     return left
   cPut (MemoryConnection ref _) newBytes = do


### PR DESCRIPTION
Connections should be able to select their own preferred read size.
This removes some more or less arbitrary, hard coded values from
the deserialization path.

Additionally, this enables connections to be smarter regarding pre-allocated receive buffers and the like.

In order to make framedTransport work with this new change it has to track leftovers just like the unframedTransport does. No big deal. In fact, the code simplifies nicely.
