### PR TITLE
Connections run the message builder

### DIFF
--- a/pinch.cabal
+++ b/pinch.cabal
@@ -63,6 +63,7 @@ library
       Pinch.Protocol.Compact
       Pinch.Server
       Pinch.Transport
+      Pinch.Transport.Builder
   other-modules:
       Pinch.Internal.Bits
       Pinch.Internal.Pinchable.Parser

--- a/src/Pinch/Internal/Builder.hs
+++ b/src/Pinch/Internal/Builder.hs
@@ -13,6 +13,7 @@
 module Pinch.Internal.Builder
     ( Builder
     , runBuilder
+    , unsafeRunBuilder
 
     , append
     , int8
@@ -47,6 +48,12 @@ data Builder = B {-# UNPACK #-} !Int (Ptr Word8 -> IO ())
 runBuilder :: Builder -> ByteString
 runBuilder (B size fill) = BI.unsafeCreate size fill
 {-# INLINE runBuilder #-}
+
+-- | Fill a buffer with the bytes of a builder. The buffer is assumed
+-- to be big enough to hold the contents of the entire builder.
+unsafeRunBuilder :: Builder -> Ptr Word8 -> IO ()
+unsafeRunBuilder (B _size fill) = fill
+{-# INLINE unsafeRunBuilder #-}
 
 -- | Append two Builders into one.
 append :: Builder -> Builder -> Builder

--- a/src/Pinch/Transport/Builder.hs
+++ b/src/Pinch/Transport/Builder.hs
@@ -1,0 +1,17 @@
+-- |
+-- Module      :  Pinch.Transport.Builder
+-- Copyright   :  (c) Abhinav Gupta 2023
+-- License     :  BSD3
+--
+-- Maintainer  :  Abhinav Gupta <mail@abhinavg.net>
+-- Stability   :  experimental
+--
+-- This module implements a ByteString builder very similar to
+-- 'Data.ByteString.Builder' except that it keeps track of its final serialized
+-- length. This allows it to allocate the target ByteString in one @malloc@ and
+-- simply write the bytes to it.
+module Pinch.Transport.Builder 
+    ( module B
+    ) where
+
+import Pinch.Internal.Builder as B


### PR DESCRIPTION
This pushes buffer allocation out of pinch core to the edge where users can
choose how to handle allocation. With this change it's now possible to use
pre-allocated write and read buffers for clients and servers.

@abhinav in the other PR you mentioned 

> However, that should probably be its own separate PR, and it'll also probably require moving Builder to a non-Internal namespace . Possibly Pinch.Transport.Builder? We could leave the implementation inside Pinch.Internal.Builder with exposed internals, and a more minimized, safer API exported in Pinch.Transport.Builder.

How do we want to approach this? I've added an unsafeRunBuilder which is the minimum requirement. Let me know what additional changes you want to see to make it work for you. 

