### PR TITLE
ci/push: Run only for push to default branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: master
+
 name: build
 jobs:
   build:


### PR DESCRIPTION
Right now, PRs with a branch pushed to this repository
run two bilds for each case:
one for the push event and one for the PR event.

This switches to running the push builds
only for pushes to master.
