### PR TITLE
Support for GHC 9.8

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ghc: ['8.4.4', '8.6.5', '8.8.3', '8.10.2', '9.0.1', '9.2.1', '9.4.2']
+        ghc: ['8.4.4', '8.6.5', '8.8.3', '8.10.2', '9.0.1', '9.2.1', '9.4.2', '9.6.3', '9.8.1']
         os: [ubuntu-latest]
       fail-fast: false
     name: GHC ${{ matrix.ghc }}

--- a/pinch.cabal
+++ b/pinch.cabal
@@ -76,10 +76,10 @@ library
   build-depends:
       array >=0.5
     , base >=4.7 && <5
-    , bytestring >=0.10 && <0.12
+    , bytestring >=0.10 && <0.13
     , cereal >=0.5.8.1 && <0.6
     , containers >=0.5 && <0.7
-    , deepseq >=1.3 && <1.5
+    , deepseq >=1.3 && <1.6
     , ghc-prim
     , hashable >=1.2 && <1.5
     , network >=3.1.2.0 && <3.2
@@ -117,7 +117,7 @@ test-suite pinch-spec
       QuickCheck >=2.5
     , async >=2.2.2 && <2.3
     , base >=4.7 && <5
-    , bytestring >=0.10 && <0.12
+    , bytestring >=0.10 && <0.13
     , cereal >=0.5.8.1 && <0.6
     , containers >=0.5 && <0.7
     , hspec >=2.0


### PR DESCRIPTION
This PR contains small updates for GHC 9.8, including dependency bounds and addressing new warnings due to uses of `Data.List.head`

Fixed #58 