### PR TITLE
Allow newer dependencies, test GHC 9.10.1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ghc: ['8.4.4', '8.6.5', '8.8.3', '8.10.2', '9.0.1', '9.2.1', '9.4.2', '9.6.3', '9.8.1']
+        ghc: ['8.4.4', '8.6.5', '8.8.4', '8.10.7', '9.0.1', '9.2.8', '9.4.8', '9.6.6', '9.8.2', '9.10.1']
         os: [ubuntu-latest]
       fail-fast: false
     name: GHC ${{ matrix.ghc }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Haskell
-        uses: haskell/actions/setup@v1
+        uses: haskell-actions/setup@v2
         with:
           cabal-version: latest
           ghc-version: ${{ matrix.ghc }}

--- a/package.yaml
+++ b/package.yaml
@@ -38,8 +38,8 @@ dependencies:
   - base >= 4.7 && < 5
   - bytestring >= 0.10 && < 0.13
   - cereal >= 0.5.8.1 && < 0.6
-  - containers >= 0.5 && < 0.7
-  - network >= 3.1.2.0 && < 3.2
+  - containers >= 0.5 && < 0.8
+  - network >= 3.1.2.0 && < 3.3
   - text >= 1.2 && < 1.3 || >= 2.0
   - unordered-containers >= 0.2 && < 0.3
   - vector >= 0.10 && < 0.14
@@ -72,7 +72,7 @@ library:
     - array >= 0.5
     - deepseq >= 1.3 && < 1.6
     - ghc-prim
-    - hashable >= 1.2 && < 1.5
+    - hashable >= 1.2 && < 1.6
 
 tests:
   pinch-spec:
@@ -81,6 +81,6 @@ tests:
     dependencies:
       - async >= 2.2.2 && < 2.3
       - hspec >= 2.0
-      - network-run >= 0.2.4 && < 0.3
+      - network-run >= 0.2.4 && < 0.4
       - pinch
       - QuickCheck >= 2.5

--- a/pinch.cabal
+++ b/pinch.cabal
@@ -78,11 +78,11 @@ library
     , base >=4.7 && <5
     , bytestring >=0.10 && <0.13
     , cereal >=0.5.8.1 && <0.6
-    , containers >=0.5 && <0.7
+    , containers >=0.5 && <0.8
     , deepseq >=1.3 && <1.6
     , ghc-prim
-    , hashable >=1.2 && <1.5
-    , network >=3.1.2.0 && <3.2
+    , hashable >=1.2 && <1.6
+    , network >=3.1.2.0 && <3.3
     , semigroups >=0.18 && <0.21
     , text >=1.2 && <1.3 || >=2.0
     , unordered-containers ==0.2.*
@@ -119,10 +119,10 @@ test-suite pinch-spec
     , base >=4.7 && <5
     , bytestring >=0.10 && <0.13
     , cereal >=0.5.8.1 && <0.6
-    , containers >=0.5 && <0.7
+    , containers >=0.5 && <0.8
     , hspec >=2.0
-    , network >=3.1.2.0 && <3.2
-    , network-run >=0.2.4 && <0.3
+    , network >=3.1.2.0 && <3.3
+    , network-run >=0.2.4 && <0.4
     , pinch
     , semigroups >=0.18 && <0.21
     , text >=1.2 && <1.3 || >=2.0


### PR DESCRIPTION
Tested using

    cabal test -w ghc-9.10.1 -c 'containers>=0.7' -c 'network>=3.2' -c 'hashable>=1.5' -c 'network-run>=0.3' "--allow-newer=*:hashable"

Fixes #61

This also addresses Stackage issues like

* https://github.com/commercialhaskell/stackage/issues/7381